### PR TITLE
Migrating `Router` protocol from the `ObservableObject` to the `@Observable`

### DIFF
--- a/VimConf2024Package/Sources/Apps/VimConf2024/DefaultRouter.swift
+++ b/VimConf2024Package/Sources/Apps/VimConf2024/DefaultRouter.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import SessionFeature
 import RoutingCore
 
+@Observable
 final class DefaultRouter {}
 
 extension DefaultRouter: Router {

--- a/VimConf2024Package/Sources/Apps/VimConf2024/VimConf2024Package.swift
+++ b/VimConf2024Package/Sources/Apps/VimConf2024/VimConf2024Package.swift
@@ -8,7 +8,7 @@ public struct RootScreen: View {
     public var body: some View {
         NavigationStack {
             TimetableScreen<DefaultRouter>()
-                .environmentObject(router)
+                .environment(router)
         }
     }
 

--- a/VimConf2024Package/Sources/Core/Routing/Router.swift
+++ b/VimConf2024Package/Sources/Core/Routing/Router.swift
@@ -1,7 +1,7 @@
 package import SwiftUI
 
 @MainActor
-package protocol Router: Sendable, ObservableObject {
+package protocol Router: AnyObject, Observable, Sendable {
     associatedtype DestinationType: View
     func navigate(to destination: Destination) -> DestinationType
 }

--- a/VimConf2024Package/Sources/Features/Timetable/Timetable/TimetableScreen.swift
+++ b/VimConf2024Package/Sources/Features/Timetable/Timetable/TimetableScreen.swift
@@ -14,7 +14,7 @@ enum TimetableScreenAsyncAction {
 // MARK: - View
 
 package struct TimetableScreen<R: Router>: View {
-    @EnvironmentObject private var router: R
+    @Environment(R.self) private var router
     @State private var viewModel: TimetableViewModel
 
     package var body: some View {


### PR DESCRIPTION
<blockquote class="twitter-tweet"><p lang="ja" dir="ltr">@ Environment(Library.self) private var library<br>のLibraryをプロトコルにしたい！</p>&mdash; ウホーイ (@the_uhooi) <a href="https://twitter.com/the_uhooi/status/1890262371807162580?ref_src=twsrc%5Etfw">February 14, 2025</a></blockquote>